### PR TITLE
Fix: HR80/HR92 heat demand switch not re-evaluated

### DIFF
--- a/main/mainworker.cpp
+++ b/main/mainworker.cpp
@@ -6275,6 +6275,7 @@ void MainWorker::decode_evohome3(const int HwdID, const _eHardwareTypes HwdType,
 		{
 			BatteryLevel = pEvo->EVOHOME3.battery_level;
 			szDemand = result[0][6];
+			cmnd=(atoi(szDemand.c_str())>0)?light1_sOn:light1_sOff;
 		}
 		if(Unit==0xFF)
 		{


### PR DESCRIPTION
Added a re-evaluation of the switch status when the heat demand is obtained from the DB in case of a battery info message.
At reception of a battery update packet from a HR80/HR92, the heat demand information is not sent along.
Code uses previous value from the DB, but the switch status (0 = off; >0 = on) was only determined correctly if the information was sent.